### PR TITLE
Use relative improts

### DIFF
--- a/src/components/send-payment/confirm-payment.tsx
+++ b/src/components/send-payment/confirm-payment.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { Button, Heading, Profile } from "@stellar/design-system";
-import { NetworkDetails, signTx } from "helpers/network";
+import { NetworkDetails, signTx } from "../../helpers/network";
 import {
   makePayment,
   getTxBuilder,
   parseTokenAmount,
   getServer,
-} from "helpers/soroban";
+} from "../../helpers/soroban";
 
 interface ConfirmPaymentProps {
   amount: string;

--- a/src/components/send-payment/index.tsx
+++ b/src/components/send-payment/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { createPortal } from "react-dom";
 import {
   Card,
   Caption,
@@ -9,9 +10,12 @@ import {
 } from "@stellar/design-system";
 import freighterApi from "@stellar/freighter-api";
 
-import { connectNetwork, Networks, NetworkDetails } from "helpers/network";
-import { createPortal } from "react-dom";
-import { ERRORS } from "helpers/error";
+import {
+  connectNetwork,
+  Networks,
+  NetworkDetails,
+} from "../../helpers/network";
+import { ERRORS } from "../../helpers/error";
 import {
   getTxBuilder,
   BASE_FEE,
@@ -21,7 +25,7 @@ import {
   getTokenBalance,
   getServer,
   submitTx,
-} from "helpers/soroban";
+} from "../../helpers/soroban";
 
 import { SendAmount } from "./send-amount";
 import { ConnectWallet } from "./connect-wallet";
@@ -41,7 +45,7 @@ interface SendPaymentProps {
 }
 
 export const SendPayment = (props: SendPaymentProps) => {
-  const showHeader = props.showHeader || true;
+  const showHeader = props.showHeader === undefined ? true : props.showHeader;
   const [activeNetworkDetails, setActiveNetworkDetails] = React.useState(
     {} as NetworkDetails,
   );

--- a/src/components/send-payment/send-amount.tsx
+++ b/src/components/send-payment/send-amount.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent } from "react";
 import BigNumber from "bignumber.js";
 import { Button, Heading, Input } from "@stellar/design-system";
-import { formatTokenAmount } from "helpers/format";
+import { formatTokenAmount } from "../../helpers/format";
 
 interface SendAmountProps {
   amount: string;

--- a/src/components/send-payment/submit-payment.tsx
+++ b/src/components/send-payment/submit-payment.tsx
@@ -8,7 +8,7 @@ import {
   Loader,
   Profile,
 } from "@stellar/design-system";
-import { copyContent } from "helpers/dom";
+import { copyContent } from "../../helpers/dom";
 
 interface SubmitPaymentProps {
   amount: string;

--- a/src/components/send-payment/tx-result.tsx
+++ b/src/components/send-payment/tx-result.tsx
@@ -6,7 +6,7 @@ import {
   Icon,
   Heading,
 } from "@stellar/design-system";
-import { copyContent } from "helpers/dom";
+import { copyContent } from "../../helpers/dom";
 
 interface TxResultProps {
   resultXDR: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import ReactDOM from "react-dom/client";
 
-import { SendPayment } from "components/send-payment";
+import { SendPayment } from "./components/send-payment";
 
 import "@stellar/design-system/build/styles.min.css";
 import "./index.scss";


### PR DESCRIPTION
Updates to using relative imports so that the demo picker can properly import paths in the git submodule.
Fixes a faulty default prop for `showHeader`