### PR TITLE
update from 'showHeader' to 'hasHeader'

### DIFF
--- a/src/components/send-payment/index.tsx
+++ b/src/components/send-payment/index.tsx
@@ -41,11 +41,11 @@ import "./index.scss";
 type StepCount = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
 interface SendPaymentProps {
-  showHeader?: boolean;
+  hasHeader?: boolean;
 }
 
 export const SendPayment = (props: SendPaymentProps) => {
-  const showHeader = props.showHeader === undefined ? true : props.showHeader;
+  const hasHeader = props.hasHeader === undefined ? true : props.hasHeader;
   const [activeNetworkDetails, setActiveNetworkDetails] = React.useState(
     {} as NetworkDetails,
   );
@@ -275,7 +275,7 @@ export const SendPayment = (props: SendPaymentProps) => {
 
   return (
     <>
-      {showHeader && (
+      {hasHeader && (
         <Layout.Header hasThemeSwitch projectId="soroban-react-payment" />
       )}
       <div className="Layout__inset account-badge-row">


### PR DESCRIPTION
- following product convention's [Booleans should be named with is, has, did, etc.](https://github.com/stellar/product-conventions/blob/master/STYLEGUIDE.md#booleans-should-be-named-with-is-has-did-etc)